### PR TITLE
Proper directionality

### DIFF
--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -46,10 +46,7 @@ fn check_cis_trans_configuration(node: &Node, atom_idx: usize) {
         match edge.kind {
             BondKind::Up | BondKind::Down => {
                 if seen_directional_bond {
-                    panic!(
-                        "Conflicting stereochemistry at atom index {}: {:?}",
-                        atom_idx, node
-                    );
+                    panic!("Conflicting stereochemistry at atom index {atom_idx}: {node:?}",);
                 } else {
                     seen_directional_bond = true;
                 }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -40,22 +40,6 @@ pub struct Builder {
     rid: usize,
 }
 
-fn check_cis_trans_configuration(node: &Node, atom_idx: usize) {
-    let mut seen_directional_bond = false;
-    for edge in &node.edges {
-        match edge.kind {
-            BondKind::Up | BondKind::Down => {
-                if seen_directional_bond {
-                    panic!("Conflicting stereochemistry at atom index {atom_idx}: {node:?}",);
-                } else {
-                    seen_directional_bond = true;
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
 impl Builder {
     /// Builds the representation created by using the `Follower` trait
     /// methods.
@@ -64,27 +48,27 @@ impl Builder {
             return Err(error);
         }
 
-        let mut result = Vec::new();
+        self.graph
+            .into_iter()
+            .enumerate()
+            .map(|(idx, node)| {
+                node.check_stereo(idx);
 
-        for (idx, node) in self.graph.iter().enumerate() {
-            let mut bonds = Vec::new();
+                let bonds = node
+                    .edges
+                    .into_iter()
+                    .map(|edge| match edge.target {
+                        Target::Id(tid) => Ok(Bond::new(edge.kind, tid)),
+                        Target::Rnum(rid, _, _) => Err(Error::Rnum(rid)),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
 
-            check_cis_trans_configuration(node, idx);
-
-            for edge in &node.edges {
-                match edge.target {
-                    Target::Id(tid) => bonds.push(Bond::new(edge.kind, tid)),
-                    Target::Rnum(rid, _, _) => return Err(Error::Rnum(rid)),
-                }
-            }
-
-            result.push(Atom {
-                kind: node.kind,
-                bonds,
-            });
-        }
-
-        Ok(result)
+                Ok(Atom {
+                    kind: node.kind,
+                    bonds,
+                })
+            })
+            .collect()
     }
 }
 
@@ -176,6 +160,41 @@ impl Node {
 
     fn add_edge(&mut self, kind: BondKind, target: Target) {
         self.edges.push(Edge::new(kind, target));
+    }
+
+    /// Ensure there’s at most one stereo-directional bond.
+    ///
+    /// # Panics
+    /// Panic if there are >=2 [`BondKind::Up`] bonds or >=2 [`BondKind::Down`] bonds.
+    fn check_stereo(&self, atom_idx: usize) {
+        let mut up_count = 0;
+        let mut down_count = 0;
+
+        for edge in &self.edges {
+            match edge.kind {
+                BondKind::Up => {
+                    up_count += 1;
+                    if up_count > 1 {
+                        panic!(
+                            "Conflicting stereochemistry (multiple Up bonds) \
+                             at atom index {}: {:?}",
+                            atom_idx, self
+                        );
+                    }
+                }
+                BondKind::Down => {
+                    down_count += 1;
+                    if down_count > 1 {
+                        panic!(
+                            "Conflicting stereochemistry (multiple Down bonds) \
+                             at atom index {}: {:?}",
+                            atom_idx, self
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 }
 

--- a/src/read/read_bracket.rs
+++ b/src/read/read_bracket.rs
@@ -30,9 +30,18 @@ fn lex_bracket_contents(scanner: &mut Scanner) -> Result<AtomKind, ReadError> {
 
     // 5. The rest are all optional
     let configuration = read_configuration(scanner);
+
+    // remember where we are for eventual error
+    let hcount_pos = scanner.cursor();
     let hcount = read_hcount(scanner);
     let charge = read_charge(scanner);
     let map = read_map(scanner)?;
+
+    if let Some(Symbol::Aliphatic(element)) = symbol {
+        if element == Element::H && hcount.is_some() {
+            return Err(ReadError::Character(hcount_pos));
+        }
+    }
 
     match scanner.peek() {
         Some(']') => {
@@ -142,6 +151,14 @@ mod tests {
     use crate::feature::{Charge, Configuration, Symbol};
     use crate::Element;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn hh1() {
+        let mut scanner = Scanner::new("[HH1]");
+        let atom = read_bracket(&mut scanner);
+
+        assert_eq!(atom, Err(ReadError::Character(2)))
+    }
 
     #[test]
     fn a_x() {

--- a/src/read/read_bracket.rs
+++ b/src/read/read_bracket.rs
@@ -1,5 +1,3 @@
-use crate::Element;
-
 use crate::Isotope;
 
 use super::{
@@ -30,18 +28,9 @@ fn lex_bracket_contents(scanner: &mut Scanner) -> Result<AtomKind, ReadError> {
 
     // 5. The rest are all optional
     let configuration = read_configuration(scanner);
-
-    // remember where we are for eventual error
-    let hcount_pos = scanner.cursor();
     let hcount = read_hcount(scanner);
     let charge = read_charge(scanner);
     let map = read_map(scanner)?;
-
-    if let Some(Symbol::Aliphatic(element)) = symbol {
-        if element == Element::H && hcount.is_some() {
-            return Err(ReadError::Character(hcount_pos));
-        }
-    }
 
     match scanner.peek() {
         Some(']') => {
@@ -151,14 +140,6 @@ mod tests {
     use crate::feature::{Charge, Configuration, Symbol};
     use crate::Element;
     use pretty_assertions::assert_eq;
-
-    #[test]
-    fn hh1() {
-        let mut scanner = Scanner::new("[HH1]");
-        let atom = read_bracket(&mut scanner);
-
-        assert_eq!(atom, Err(ReadError::Character(2)))
-    }
 
     #[test]
     fn a_x() {

--- a/src/read/read_bracket.rs
+++ b/src/read/read_bracket.rs
@@ -1,3 +1,5 @@
+use crate::Element;
+
 use crate::Isotope;
 
 use super::{
@@ -14,7 +16,7 @@ fn lex_bracket_contents(scanner: &mut Scanner) -> Result<AtomKind, ReadError> {
     // Read the symbol
     let symbol = read_symbol(scanner)?;
 
-    // Build optional `Isotope` only if `symbol` is an [`Element`]
+    // Build optional `Isotope` only if `symbol` is an `Element`
     let isotope = if let Some(Symbol::Aliphatic(el)) = symbol {
         iso_num_opt.and_then(|mass| {
             Isotope::list()

--- a/src/read/read_bracket.rs
+++ b/src/read/read_bracket.rs
@@ -100,11 +100,7 @@ fn read_isotope(scanner: &mut Scanner) -> Option<u16> {
         }
     }
 
-    if digits.is_empty() {
-        None
-    } else {
-        Some(digits.parse::<u16>().expect("number"))
-    }
+    digits.parse::<u16>().ok()
 }
 
 fn read_map(scanner: &mut Scanner) -> Result<Option<u16>, ReadError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -113,9 +113,17 @@ fn special_case_temp_iupac_names() {
 }
 
 #[test]
-#[should_panic(expected = "Conflicting stereochemistry at atom index 1")]
-fn check_proper_directionality() {
+#[should_panic(expected = "Conflicting stereochemistry (multiple ")]
+fn invalid_stereochemistry() {
     let smiles = "C/C(\\F)=C/F";
+    let mut builder = Builder::default();
+    read(smiles, &mut builder, None).unwrap();
+    builder.build().expect("atoms");
+}
+
+#[test]
+fn valid_stereochemistry() {
+    let smiles = "N/C(/O)=C(\\S)/F";
     let mut builder = Builder::default();
     read(smiles, &mut builder, None).unwrap();
     builder.build().expect("atoms");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -111,3 +111,12 @@ fn special_case_temp_iupac_names() {
     let written_smiles = writer.write();
     assert_eq!(written_smiles, expected_smiles);
 }
+
+#[test]
+#[should_panic(expected = "Conflicting stereochemistry at atom index 1")]
+fn check_proper_directionality() {
+    let smiles = "C/C(\\F)=C/F";
+    let mut builder = Builder::default();
+    read(smiles, &mut builder, None).unwrap();
+    builder.build().expect("atoms");
+}


### PR DESCRIPTION
fixes #14 

initially, it also change that a hydrogen atom cannot have a hydrogen count, for example, `[HH1]` is illegal as specified by the OpenSMILES specification. But, instead we lean against what RDKit allows which is that hydrogens can have a hydrogen count