### PR TITLE
Scanner work on &str + rewrite join in Builder

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -2,25 +2,25 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use yowl::graph::Builder;
 use yowl::read::read;
 
-fn benchmark_smiles_parsing(c: &mut Criterion) {
-    let smiles_strings = vec![
-        "CO",                                                                        // Simple molecule
-        "C1=CC=CC=C1",                                                               // Benzene
-        "C[C@H](O)[C@@H](O)C(=O)O",                                                  // Lactic acid
-        "C1CC1C(=O)O", // Cyclopropanecarboxylic acid
-        "[Db][Sg][Bh][Hs][Mt][Ds][Rg][Cn][Nh][Fl][Mc][Lv][Ts][Og]", // Novel elements
-        "O=Cc1ccc(O)c(OC)c1COc1cc(C=O)ccc1O", // Vanilin
-        "CC(=O)NCCC1=CNc2c1cc(OC)cc2CC(=O)NCCc1c[nH]c2ccc(OC)cc12", // Melatonin
-        "CC1=C(C(=O)C[C@@H]1OC(=O)[C@@H]2[C@H](C2(C)C)/C=C(\\C)/C(=O)OC)C/C=C\\C=C", // Pyrethrin II
-        "OC[C@@H](O1)[C@@H](O)[C@H](O)[C@@H]2[C@@H]1c3c(O)c(OC)c(O)cc3C(=O)O2", // Bergenin
-        "CC(=O)OCCC(/C)=C\\C[C@H](C(C)=C)CCC=C", // a pheromone of the Californian scale insect
-        "CC[C@H](O1)CC[C@@]12CCCO2", // (2S,2R)-Chalgogran
-        "OCCc1c(C)[n+](cs1)Cc2cnc(C)nc2N", // Thiamine
-    ];
+const SMILES_STRINGS: [&str; 12] = [
+    "CO",                                                                        // Simple molecule
+    "C1=CC=CC=C1",                                                               // Benzene
+    "C[C@H](O)[C@@H](O)C(=O)O",                                                  // Lactic acid
+    "C1CC1C(=O)O", // Cyclopropanecarboxylic acid
+    "[Db][Sg][Bh][Hs][Mt][Ds][Rg][Cn][Nh][Fl][Mc][Lv][Ts][Og]", // Novel elements
+    "O=Cc1ccc(O)c(OC)c1COc1cc(C=O)ccc1O", // Vanilin
+    "CC(=O)NCCC1=CNc2c1cc(OC)cc2CC(=O)NCCc1c[nH]c2ccc(OC)cc12", // Melatonin
+    "CC1=C(C(=O)C[C@@H]1OC(=O)[C@@H]2[C@H](C2(C)C)/C=C(\\C)/C(=O)OC)C/C=C\\C=C", // Pyrethrin II
+    "OC[C@@H](O1)[C@@H](O)[C@H](O)[C@@H]2[C@@H]1c3c(O)c(OC)c(O)cc3C(=O)O2", // Bergenin
+    "CC(=O)OCCC(/C)=C\\C[C@H](C(C)=C)CCC=C", // a pheromone of the Californian scale insect
+    "CC[C@H](O1)CC[C@@]12CCCO2", // (2S,2R)-Chalgogran
+    "OCCc1c(C)[n+](cs1)Cc2cnc(C)nc2N", // Thiamine
+];
 
+fn benchmark_smiles_parsing(c: &mut Criterion) {
     c.bench_function("parse_smiles", |b| {
         b.iter(|| {
-            for smiles in &smiles_strings {
+            for smiles in &SMILES_STRINGS {
                 let mut builder = Builder::default();
                 read(smiles, &mut builder, None).unwrap();
             }

--- a/src/read/read_bracket.rs
+++ b/src/read/read_bracket.rs
@@ -95,7 +95,7 @@ fn read_isotope(scanner: &mut Scanner) -> Option<u16> {
 
     for _ in 0..3 {
         match scanner.peek() {
-            Some('0'..='9') => digits.push(*scanner.pop().expect("digit")),
+            Some('0'..='9') => digits.push(scanner.pop().expect("digit")),
             _ => break,
         }
     }
@@ -113,7 +113,7 @@ fn read_map(scanner: &mut Scanner) -> Result<Option<u16>, ReadError> {
             match scanner.pop() {
                 Some(next) => {
                     if next.is_ascii_digit() {
-                        digits.push(*next);
+                        digits.push(next);
                     } else {
                         return Err(ReadError::Character(scanner.cursor() - 1));
                     }
@@ -123,7 +123,7 @@ fn read_map(scanner: &mut Scanner) -> Result<Option<u16>, ReadError> {
 
             for _ in 0..2 {
                 match scanner.peek() {
-                    Some('0'..='9') => digits.push(*scanner.pop().expect("digit")),
+                    Some('0'..='9') => digits.push(scanner.pop().expect("digit")),
                     _ => break,
                 }
             }

--- a/src/read/read_charge.rs
+++ b/src/read/read_charge.rs
@@ -24,7 +24,7 @@ fn next_charge_token(scanner: &mut Scanner) -> Option<ChargeToken> {
             // try multi-digit or default
             if let Some(n) = lex_fifteen(scanner) {
                 Some(ChargeToken::Signed(n))
-            } else if scanner.peek() == Some(&'+') {
+            } else if scanner.peek() == Some('+') {
                 scanner.pop();
                 Some(ChargeToken::Plus2)
             } else {
@@ -35,7 +35,7 @@ fn next_charge_token(scanner: &mut Scanner) -> Option<ChargeToken> {
             scanner.pop();
             if let Some(n) = lex_fifteen(scanner) {
                 Some(ChargeToken::Signed(-n))
-            } else if scanner.peek() == Some(&'-') {
+            } else if scanner.peek() == Some('-') {
                 scanner.pop();
                 Some(ChargeToken::Minus2)
             } else {

--- a/src/read/read_organic.rs
+++ b/src/read/read_organic.rs
@@ -48,7 +48,7 @@ fn next_atom_token(scanner: &mut Scanner) -> Result<Option<AtomToken>, ReadError
         // aliphatic: two-char combos first
         Some('B') => {
             scanner.pop();
-            if scanner.peek() == Some(&'r') {
+            if scanner.peek() == Some('r') {
                 scanner.pop();
                 Ok(Some(AtomToken::Aliphatic(Element::Br)))
             } else {
@@ -57,7 +57,7 @@ fn next_atom_token(scanner: &mut Scanner) -> Result<Option<AtomToken>, ReadError
         }
         Some('C') => {
             scanner.pop();
-            if scanner.peek() == Some(&'l') {
+            if scanner.peek() == Some('l') {
                 scanner.pop();
                 Ok(Some(AtomToken::Aliphatic(Element::Cl)))
             } else {
@@ -66,7 +66,7 @@ fn next_atom_token(scanner: &mut Scanner) -> Result<Option<AtomToken>, ReadError
         }
         Some('T') => {
             scanner.pop();
-            if scanner.peek() == Some(&'s') {
+            if scanner.peek() == Some('s') {
                 scanner.pop();
                 Ok(Some(AtomToken::Aliphatic(Element::Ts)))
             } else {
@@ -75,7 +75,7 @@ fn next_atom_token(scanner: &mut Scanner) -> Result<Option<AtomToken>, ReadError
         }
         Some('A') => {
             scanner.pop();
-            if scanner.peek() == Some(&'t') {
+            if scanner.peek() == Some('t') {
                 scanner.pop();
                 Ok(Some(AtomToken::Aliphatic(Element::At)))
             } else {

--- a/src/read/read_rnum.rs
+++ b/src/read/read_rnum.rs
@@ -13,7 +13,7 @@ fn next_rnum_token(scanner: &mut Scanner) -> Result<Option<RnumToken>, ReadError
     let result = match scanner.peek() {
         // single digit
         Some('0'..='9') => {
-            let c = *scanner.pop().unwrap();
+            let c = scanner.pop().unwrap();
             let d = u8::try_from(c.to_digit(10).unwrap()).expect("rnum to u8");
 
             Ok(Some(RnumToken::Digit(d)))
@@ -25,7 +25,7 @@ fn next_rnum_token(scanner: &mut Scanner) -> Result<Option<RnumToken>, ReadError
 
             // first digit
             let c1 = match scanner.peek() {
-                Some(next) if next.is_ascii_digit() => *next,
+                Some(next) if next.is_ascii_digit() => next,
                 _ => return Err(missing_character(scanner)),
             };
             scanner.pop();
@@ -34,7 +34,7 @@ fn next_rnum_token(scanner: &mut Scanner) -> Result<Option<RnumToken>, ReadError
 
             // second digit
             let c2 = match scanner.peek() {
-                Some(next) if next.is_ascii_digit() => *next,
+                Some(next) if next.is_ascii_digit() => next,
                 _ => return Err(missing_character(scanner)),
             };
             scanner.pop();

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -124,7 +124,7 @@ fn read_branch<F: Follower>(
         _ => return Ok(false),
     }
 
-    let length = if scanner.peek() == Some(&'.') {
+    let length = if scanner.peek() == Some('.') {
         scanner.pop();
 
         match read_smiles(None, scanner, follower, trace)? {


### PR DESCRIPTION
also moves the benchmark to use a `const` array of strings